### PR TITLE
If you're using windows, you have bigger problems

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,31 +34,6 @@ jobs:
       - name: Test
         run: cargo test --release --verbose
 
-  test-windows:
-    name: Build and Text on Windows
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        toolchain:
-          - stable
-          - beta
-          - nightly
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          cache-key: ${{ runner.os }}-${{ matrix.toolchain }}
-
-      - name: Build
-        run: cargo build --release --verbose
-
-      - name: Test
-        run: cargo test --release --verbose
-
   test-macos:
     name: Build and Text on MacOS
     runs-on: macos-latest


### PR DESCRIPTION
This pull request simplifies the CI/CD workflow by removing the `test-windows` job from the `.github/workflows/release.yml` file.

Key change:

* Removed the `test-windows` job, which included steps for checking out the code, setting up Rust toolchains, building the project, and running tests on Windows environments. This simplifies the workflow by eliminating Windows-specific testing.